### PR TITLE
서버 api에 사용되는 응답값 타입 추가

### DIFF
--- a/src/types/api/constants.ts
+++ b/src/types/api/constants.ts
@@ -1,0 +1,1 @@
+export type CATEGORY = "ad" | "question" | "consulting";

--- a/src/types/api/postDetail.ts
+++ b/src/types/api/postDetail.ts
@@ -1,0 +1,19 @@
+import { CATEGORY } from "./constants";
+
+export interface PostDetail {
+  postId: number;
+  title: string;
+  content: string;
+  category: CATEGORY;
+  creator: string;
+  viewCount: number;
+  comments: Comment[];
+}
+
+interface Comment {
+  commentId: number;
+  content: string;
+  creator: string;
+  createdAt: string;
+  childrenCommentCount: number;
+}

--- a/src/types/api/postList.ts
+++ b/src/types/api/postList.ts
@@ -1,0 +1,17 @@
+import { CATEGORY } from "./constants";
+
+export interface PostList {
+  elementsCount: number;
+  content: Post[];
+}
+
+interface Post {
+  postId: number;
+  title: string;
+  content: string;
+  category: CATEGORY;
+  creator: string;
+  viewCount: number;
+  commentCount: number;
+  createdAt: string;
+}


### PR DESCRIPTION
추가된 곳 /src/types/api

1.서버 api 에서 사용되는 공통 타입 (common.ts)
2.게시글 조회 타입 추가 (postList.ts)
3.게시글 상세 타입 추가 (postDetail.ts)